### PR TITLE
Customizing build for other platforms

### DIFF
--- a/libs/Pinsec.h
+++ b/libs/Pinsec.h
@@ -8,8 +8,11 @@
 #ifndef MAPPING_H_
 #define MAPPING_H_
 
+#ifdef CONFIG_CORE_HZ
+#define CORE_HZ CONFIG_CORE_HZ
+#else
 #define CORE_HZ 100000000
-
+#endif
 
 #define GPIO_A_BASE    ((volatile uint32_t*)(0xF0000000))
 #define GPIO_B_BASE    ((volatile uint32_t*)(0xF0001000))

--- a/tests/cDemo/makefile
+++ b/tests/cDemo/makefile
@@ -13,11 +13,8 @@ INC += -I../../libs/test/
 INC += -I../../libs/timer/
 INC += -I../../libs/interrupt/
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 
 
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/cDemo/src/main.c
+++ b/tests/cDemo/src/main.c
@@ -2,8 +2,8 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <Pinsec.h>
 
-#define CORE_HZ 100000000
 
 struct Uart{
    uint32_t readWrite;

--- a/tests/dhrystone/makefile
+++ b/tests/dhrystone/makefile
@@ -18,11 +18,8 @@ INC += -I../../libs/test/
 INC += -I../../libs/uart/
 INC += -I../../libs/timer/
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 
 
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/dummy/makefile
+++ b/tests/dummy/makefile
@@ -9,9 +9,6 @@ SRCS = 	$(wildcard src/*.c) \
 	$(wildcard src/*.S)
 
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/gpio/makefile
+++ b/tests/gpio/makefile
@@ -9,11 +9,8 @@ SRCS = 	$(wildcard src/*.c) \
 	$(wildcard src/*.S)
 
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 
 
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/init/makefile
+++ b/tests/init/makefile
@@ -11,9 +11,6 @@ SRCS = 	$(wildcard src/*.c) \
 INC += -I../../libs/test/
 INC += -I../../libs/uart/
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/timer/makefile
+++ b/tests/timer/makefile
@@ -13,11 +13,8 @@ INC += -I../../libs/test/
 INC += -I../../libs/timer/
 INC += -I../../libs/interrupt/
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 
 
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/uart/makefile
+++ b/tests/uart/makefile
@@ -11,9 +11,6 @@ SRCS = 	$(wildcard src/*.c) \
 INC += -I../../libs/test/
 INC += -I../../libs/uart/
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/ugfx/makefile
+++ b/tests/ugfx/makefile
@@ -23,9 +23,6 @@ INC += -I../../libs/timer/
 CFLAGS += -g -ffast-math -fno-common -funsigned-char -fno-builtin-printf 
 LDFLAGS += -lm
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			

--- a/tests/vga/makefile
+++ b/tests/vga/makefile
@@ -15,9 +15,6 @@ INC += -I../../libs/
 
 CFLAGS += -g
 
-LDSCRIPT = ../../resources/linker.ld
+LDSCRIPT ?= ../../resources/linker.ld
 include ../../resources/gcc.mk
 include ../../resources/subproject.mk
-
-
-			


### PR DESCRIPTION
- making clock configurable
- making linker script configurable

The following build command using custom linker script and clock works:

```
LDSCRIPT=~/linker.ld CONFIG_CORE_HZ=50000000 make
```
