### PR TITLE
Added 8-bit VGA support

### DIFF
--- a/tests/ugfx/src/board_framebuffer.h
+++ b/tests/ugfx/src/board_framebuffer.h
@@ -7,12 +7,17 @@
 
 // Set this to your frame buffer pixel format.
 #ifndef GDISP_LLD_PIXELFORMAT
+#ifndef RGB332
 	#define GDISP_LLD_PIXELFORMAT		GDISP_PIXELFORMAT_RGB565
+	extern uint16_t vgaFramebuffer[480][640];
+#else
+	#define GDISP_LLD_PIXELFORMAT		GDISP_PIXELFORMAT_RGB332
+	extern uint8_t vgaFramebuffer[480][640];
+#endif
 #endif
 
 // Uncomment this if your frame buffer device requires flushing
 //#define GDISP_HARDWARE_FLUSH		TRUE
-extern uint16_t vgaFramebuffer[480][640];
 
 #ifdef GDISP_DRIVER_VMT
 

--- a/tests/ugfx/src/main.cpp
+++ b/tests/ugfx/src/main.cpp
@@ -2,21 +2,22 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <TestCom.h>
-#include <Uart.h>
 #include <Vga.h>
 #include <Timer.h>
 #include <Pinsec.h>
 #include "Bubble.h"
 
 
-UartCtrl uartCtrl = UartCtrl(UART_BASE);
 TimerCtrl timerA = TimerCtrl(TIMER_A_BASE);
 
 #define RES_X 640
 #define RES_Y 480
 
+#ifndef RGB332
 __attribute__ ((section (".noinit"))) __attribute__ ((aligned (4*8))) uint16_t vgaFramebuffer[RES_Y][RES_X];
+#else
+__attribute__ ((section (".noinit"))) __attribute__ ((aligned (4*8))) uint8_t vgaFramebuffer[RES_Y][RES_X];
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,21 +27,17 @@ int main() {
 	timerA.setLimit(0xFFFFFFFF);
 	timerA.setEnables(0x00010001);
 
-	uartCtrl.setClockDivider(CORE_HZ / 115200 / UART_SAMPLE_PER_BAUD);
-	uartCtrl.setFrameConfig(8,NONE,TWO);
-	uartCtrl.setReadInterruptEnable(0);
-	uartCtrl.setWriteInterruptEnable(0);
-
-	/*for(uint32_t y = 0;y < RES_Y;y++){
+	/*
+	for(uint32_t y = 0;y < RES_Y;y++){
 		for(uint32_t x = 0;x < RES_X;x++){
 			vgaFramebuffer[y][x] = (x & 0x1F) + ((y & 0x3F) << 5);
 		}
 	}
-*/
+	*/
 	VgaCtrl vgaCtrl = VgaCtrl(VGA_BASE);
     vgaCtrl.stop();
 	vgaCtrl.setTimings(vga_h640_v480_r60);
-	vgaCtrl.setFrameSize(RES_X*RES_Y*2);
+	vgaCtrl.setFrameSize(RES_X*RES_Y*sizeof(**vgaFramebuffer));
 	vgaCtrl.setFrameBase((uint32_t)vgaFramebuffer);
     vgaCtrl.run();
 
@@ -52,9 +49,9 @@ int main() {
 
 }
 
-int  times (){
-  int value = timerA.getValue();
-  return value;
+int times(void)
+{
+	return timerA.getValue();
 }
 
 systemticks_t gfxSystemTicks(void)
@@ -64,13 +61,11 @@ systemticks_t gfxSystemTicks(void)
 
 systemticks_t gfxMillisecondsToTicks(delaytime_t ms)
 {
-	return ms*50*1000;
+	return ms*(CORE_HZ/1000);
 }
 
-
-
-void irqCpp(uint32_t irq){
-
+void irqCpp(uint32_t irq)
+{
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
 - removed not working uart
 - fixed gfxMillisecondsToTicks
 - added support for 8-bit frame buffer when compiled with RGB332 defined

I have tested these changes on Nexys4DDR at 100MHz and miniSpartan6+ at 50MHz. The default is RGB565 as before. But when compiled with CFLAGS=-DRGB332, it uses 8-bit color depth, and the code fits to 400KB BRAM.